### PR TITLE
Fix encoding error in description

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,7 +176,7 @@ def download_contents(contents, total):
             entry["day"], entry["group"], entry["base_name"]
         )
         description_path = safe_filepath(DESTINATION, description_name)
-        with open(description_path, "w") as fd:
+        with open(description_path, "w", encoding="utf-8") as fd:
             fd.write(entry["description"])
         for item in entry["attachments"]:
             index += 1


### PR DESCRIPTION
Got an encoding error when downloading data. Fix was to explicitly use UTF-8 encoding, which can handle emojis and other Unicode characters.

<img width="1113" height="626" alt="image" src="https://github.com/user-attachments/assets/02ce5909-c371-4fe5-8371-e472f8444603" />
